### PR TITLE
Make PRINTER: output destination an option and default-disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.bin
+.bindir
+.mandir
+/etc/*.ps
+
 /build/
 
 # Eclipse

--- a/man/man1/ucsdpsys_vm.1
+++ b/man/man1/ucsdpsys_vm.1
@@ -96,6 +96,13 @@ Uses \f[I]system-name\fP instead of \f[CW]SYSTEM.PASCAL\fP.  In contrast
 to the original Apple system, the system file is found on any of the
 volumes.
 .TP 8n
+\fB\-p\fP\f[I][printer-file]\fP
+.TP 8n
+\fB\-\-printer\fP[=\f[I]printer-file\fP]
+Enable \f[CW]PRINTER:\fP output.  Write \f[CW]PRINTER:\fP output to
+\f[I]printer-file\fP if specified and to the default printer via \f[I]lp\fP(1)
+otherwise.
+.TP 8n
 \fB\-r\fP \f[I]volume-file\fP
 .TP 8n
 \fB\-\-read=\fP\f[I]volume-file\fP

--- a/ucsdpsys_vm/main.c
+++ b/ucsdpsys_vm/main.c
@@ -52,6 +52,7 @@
 #include <ucsdpsys_vm/sets.h>
 #include <ucsdpsys_vm/stack.h>
 #include <ucsdpsys_vm/term.h>
+#include <ucsdpsys_vm/printer.h>
 
 #undef IXP_COMPATIBILITY
 #undef TRACE_TRANSLATE
@@ -3093,6 +3094,7 @@ static const struct option options[] =
     { "version", 0, 0, 'V' },
     { "write", 1, 0, 'w' },
     { "xterm", 1, 0, 'x' },
+    { "printer", 2, 0, 'p' },
     { 0, 0, 0, 0 }
 };
 
@@ -3105,6 +3107,8 @@ main(int argc, char **argv)
     int             Unit;
     int             UseXTerm;
     int             BatchFd;
+    const char      *PrinterPath;
+    int             UsePrinter;
     const char      *SystemName;
     int             emulate_date;
     int             root_unit;
@@ -3115,6 +3119,8 @@ main(int argc, char **argv)
     Unit = 4;
     UseXTerm = 0;
     BatchFd = -1;
+    UsePrinter = 0;
+    PrinterPath = NULL;
     SystemName = "system.pascal";
     emulate_date = 1;
     memset(SegDict, 0, sizeof(SegDict));
@@ -3126,7 +3132,7 @@ main(int argc, char **argv)
 
     for (;;)
     {
-        i = getopt_long(argc, argv, "ab:Ddgn:t:T:w:r:f:xV", options, 0);
+        i = getopt_long(argc, argv, "ab:Ddgn:p::t:T:w:r:f:xV", options, 0);
         if (i == EOF)
             break;
         switch (i)
@@ -3273,6 +3279,13 @@ main(int argc, char **argv)
             UseXTerm++;
             break;
 
+        case 'p':
+            UsePrinter++;
+            if (optarg) {
+                PrinterPath = optarg;
+            }
+            break;
+
         case 'V':
             version_print();
             return 0;
@@ -3280,6 +3293,7 @@ main(int argc, char **argv)
     }
 
     TermOpen(UseXTerm, BatchFd);
+    PrinterInit(UsePrinter, PrinterPath);
 
 #ifndef WORD_MEMORY
     if (AppleCompatibility)
@@ -3366,6 +3380,7 @@ main(int argc, char **argv)
         DiskUmount(Unit);
     }
     TermClose();
+    PrinterClose();
     if (TraceFile)
         explain_fclose_or_die(TraceFile);
     return (0);

--- a/ucsdpsys_vm/printer.c
+++ b/ucsdpsys_vm/printer.c
@@ -24,8 +24,47 @@
 
 #include <ucsdpsys_vm/printer.h>
 
-
+static int UseLP = 0;
 static FILE *Printer = NULL;
+
+void
+PrinterInit(int UsePrinter, const char *PrinterPath)
+{
+    if (!UsePrinter)
+    {
+        UseLP = 0;
+        Printer = NULL;
+    }
+    else if (!PrinterPath)
+    {
+        UseLP = 1;
+        Printer = NULL;
+    }
+    else
+    {
+        UseLP = 0;
+        Printer = fopen(PrinterPath, "w");
+    }
+}
+
+void
+PrinterClose(void)
+{
+    if (!Printer)
+    {
+        /* pass */
+    }
+    else if (UseLP)
+    {
+        pclose(Printer);
+        Printer = NULL;
+    }
+    else
+    {
+        fclose(Printer);
+        Printer = NULL;
+    }
+}
 
 
 void
@@ -33,13 +72,9 @@ PrinterWrite(byte ch, word Mode)
 {
     static int Dle = 0;
 
-    if (!Printer)
+    if (UseLP && !Printer)
     {
-#ifdef PRINT_DEVICE
-        Printer = fopen(PRINT_DEVICE, "w");
-#else
         Printer = popen("lp -s", "w");
-#endif
     }
 
     if (!Printer)
@@ -87,13 +122,17 @@ PrinterWrite(byte ch, word Mode)
 void
 PrinterClear(void)
 {
-    if (Printer)
+    if (!Printer)
     {
-#ifdef PRINT_DEVICE
-        fclose(Printer);
-#else
+        /* pass */
+    }
+    else if (UseLP)
+    {
         pclose(Printer);
-#endif
         Printer = NULL;
+    }
+    else
+    {
+        fflush(Printer);
     }
 }

--- a/ucsdpsys_vm/printer.h
+++ b/ucsdpsys_vm/printer.h
@@ -21,6 +21,9 @@
 
 #include <lib/psystem.h>
 
+void PrinterInit(int UsePrinter, const char *PrinterPath);
+void PrinterClose(void);
+
 /**
   * The PrinterWrite function is used by unitwrite to send a character
   * to the printer.


### PR DESCRIPTION
Ever tried compiling some old Apple Pascal sources that have `(*$L PRINTER: *)` set?  On the one hand, the results were hilarious.  On the other hand, twice (sigh) was enough.