### PR TITLE
Minor Apple compatibility mode improvements

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -392,7 +392,7 @@ all-bin: bin/bin2c bin/float_conv bin/test_prelude bin/ucsdpsys_svolcvt bin/ucsd
 all-doc: etc/building.ps etc/change_log.ps etc/readme.ps etc/reference.ps
 
 .bin:
-	-mkdir bin
+	-mkdir -p bin
 	-chmod 0755 bin
 	@-test -d bin && touch $@
 	@sleep 1

--- a/man/man1/ucsdpsys_vm.1
+++ b/man/man1/ucsdpsys_vm.1
@@ -35,9 +35,13 @@ The following options are understood:
 \fB\-a\fP
 .TP 8n
 \fB\-\-apple\fP
+.RS
 execute the system in Apple compatibility mode.
 In Apple compatibility mode, the P-system is initialized using the
 same addresses as the original Apple ][ p-System.
+.PP
+Requires that \fI\*(n)\fP be compiled with byte mode memory.
+.RE
 .TP 8n
 \fB\-b\fP \f[I]batch-file\fP
 .TP 8n

--- a/ucsdpsys_vm/main.c
+++ b/ucsdpsys_vm/main.c
@@ -3140,6 +3140,9 @@ main(int argc, char **argv)
         case 'a':
 #ifndef WORD_MEMORY
             AppleCompatibility = 1;
+#else
+            fprintf(stderr, "Apple compatibility requires byte mode memory\n");
+            usage();
 #endif
             break;
 
@@ -3289,6 +3292,9 @@ main(int argc, char **argv)
         case 'V':
             version_print();
             return 0;
+
+        default:
+            usage();
         }
     }
 

--- a/ucsdpsys_vm/main.c
+++ b/ucsdpsys_vm/main.c
@@ -64,7 +64,7 @@ static byte     TraceProc;
 
 #define APPLE_HEAP_BOT          0x0804
 #define APPLE_KP_TOP            0xfe7c
-#define APPLE_SEG0_LOAD_GAP     0x450a
+#define APPLE_SEG0_LOAD_GAP     0x350a
 #define APPLE_SYSCOM            0xbdde
 
 #ifdef TRACE_TRANSLATE


### PR DESCRIPTION
Hopefully nothing here is too contentious.

Later, I think there needs to be a significant reshuffling to support both word- and byte-oriented memory in the same binary.  Or alternatively -- why word-oriented memory at all?  It does get up to 128k without going Harvard architecture, but word-oriented mode only seems to have been used for the GA 440, so I'm not sure what software would require that much RAM.

It's impressive that so much in the base systems works so transparently with word vs byte memory, but alas not quite everything.  Without commented sources we may never know, but the Apple Pascal linker (at least 1.1 and 1.3) appears to (a) include explicit support for word-oriented addresses, but (b) either has a bug or makes assumptions incompatible with cross-linking across address orientation, halving the values of the self-relative pointers for copied-in native procedures.